### PR TITLE
feat: monthly inventory intake report per restaurant

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from src.api.routes import predict, items, report
+from src.api.routes import predict, items, report, intake
 
 app = FastAPI(
     title="Inventory Waste Predictor API",
@@ -10,6 +10,7 @@ app = FastAPI(
 app.include_router(predict.router, prefix="/predict", tags=["Prediction"])
 app.include_router(items.router, prefix="/items", tags=["Items"])
 app.include_router(report.router, prefix="/report", tags=["Report"])
+app.include_router(intake.router, prefix="/inventory/intake", tags=["Intake"])
 
 
 @app.get("/health")

--- a/src/api/routes/intake.py
+++ b/src/api/routes/intake.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+from src.services.intake_service import get_monthly_intake
+
+router = APIRouter()
+
+
+class IntakeItem(BaseModel):
+    item_id: str
+    name: str
+    category: str
+    units_received: int
+    delivery_dates: list[str]
+
+
+class IntakeResponse(BaseModel):
+    restaurant_id: str
+    month: str
+    total_items_received: int
+    total_units: int
+    intake: list[IntakeItem]
+
+
+@router.get("/", response_model=IntakeResponse)
+def monthly_intake(
+    restaurant_id: str = Query(..., description="Restaurant identifier"),
+    month: str = Query(..., description="Month in YYYY-MM format", pattern=r"^\d{4}-\d{2}$"),
+):
+    try:
+        return get_monthly_intake(restaurant_id, month)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))

--- a/src/services/intake_service.py
+++ b/src/services/intake_service.py
@@ -1,0 +1,73 @@
+"""
+Monthly inventory intake service.
+Returns all inventory received by a restaurant in a given month.
+"""
+from datetime import date, timedelta
+from collections import defaultdict
+
+
+# In-memory store simulating intake records.
+# Replace with a real DB query when a database is wired up.
+_INTAKE_RECORDS: list[dict] = [
+    {"restaurant_id": "R001", "item_id": "SKU001", "name": "Whole Milk",      "category": "dairy",     "units": 80,  "delivery_date": "2026-03-01"},
+    {"restaurant_id": "R001", "item_id": "SKU001", "name": "Whole Milk",      "category": "dairy",     "units": 70,  "delivery_date": "2026-03-08"},
+    {"restaurant_id": "R001", "item_id": "SKU001", "name": "Whole Milk",      "category": "dairy",     "units": 50,  "delivery_date": "2026-03-15"},
+    {"restaurant_id": "R001", "item_id": "SKU002", "name": "Sourdough Bread", "category": "bakery",    "units": 120, "delivery_date": "2026-03-02"},
+    {"restaurant_id": "R001", "item_id": "SKU002", "name": "Sourdough Bread", "category": "bakery",    "units": 100, "delivery_date": "2026-03-16"},
+    {"restaurant_id": "R001", "item_id": "SKU003", "name": "Tomatoes",        "category": "produce",   "units": 60,  "delivery_date": "2026-03-03"},
+    {"restaurant_id": "R001", "item_id": "SKU003", "name": "Tomatoes",        "category": "produce",   "units": 55,  "delivery_date": "2026-03-17"},
+    {"restaurant_id": "R001", "item_id": "SKU004", "name": "Chicken Breast",  "category": "meat",      "units": 40,  "delivery_date": "2026-02-10"},
+    {"restaurant_id": "R002", "item_id": "SKU005", "name": "Olive Oil",       "category": "dry-goods", "units": 30,  "delivery_date": "2026-03-05"},
+    {"restaurant_id": "R002", "item_id": "SKU006", "name": "Pasta",           "category": "dry-goods", "units": 90,  "delivery_date": "2026-03-05"},
+    {"restaurant_id": "R002", "item_id": "SKU006", "name": "Pasta",           "category": "dry-goods", "units": 90,  "delivery_date": "2026-03-20"},
+]
+
+
+def get_monthly_intake(restaurant_id: str, month: str) -> dict:
+    """
+    Return aggregated inventory intake for a restaurant in a given month.
+
+    Args:
+        restaurant_id: Unique restaurant identifier.
+        month: Target month in YYYY-MM format.
+
+    Returns:
+        Dict with total counts and per-item breakdown.
+
+    Raises:
+        ValueError: If month format is invalid.
+    """
+    try:
+        year, mon = int(month[:4]), int(month[5:7])
+    except (ValueError, IndexError):
+        raise ValueError(f"Invalid month format '{month}'. Expected YYYY-MM.")
+
+    records = [
+        r for r in _INTAKE_RECORDS
+        if r["restaurant_id"] == restaurant_id
+        and r["delivery_date"].startswith(month)
+    ]
+
+    aggregated: dict[str, dict] = {}
+    for r in records:
+        key = r["item_id"]
+        if key not in aggregated:
+            aggregated[key] = {
+                "item_id": key,
+                "name": r["name"],
+                "category": r["category"],
+                "units_received": 0,
+                "delivery_dates": [],
+            }
+        aggregated[key]["units_received"] += r["units"]
+        aggregated[key]["delivery_dates"].append(r["delivery_date"])
+
+    intake = sorted(aggregated.values(), key=lambda x: x["item_id"])
+
+    return {
+        "restaurant_id": restaurant_id,
+        "month": month,
+        "total_items_received": len(intake),
+        "total_units": sum(i["units_received"] for i in intake),
+        "intake": intake,
+    }

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -1,0 +1,49 @@
+import pytest
+from src.services.intake_service import get_monthly_intake
+
+
+def test_returns_correct_restaurant_and_month():
+    result = get_monthly_intake("R001", "2026-03")
+    assert result["restaurant_id"] == "R001"
+    assert result["month"] == "2026-03"
+
+
+def test_total_units_and_items():
+    result = get_monthly_intake("R001", "2026-03")
+    assert result["total_items_received"] == 3  # SKU001, SKU002, SKU003
+    assert result["total_units"] == 535          # 200 + 220 + 115
+
+
+def test_per_item_breakdown():
+    result = get_monthly_intake("R001", "2026-03")
+    milk = next(i for i in result["intake"] if i["item_id"] == "SKU001")
+    assert milk["units_received"] == 200
+    assert len(milk["delivery_dates"]) == 3
+    assert milk["category"] == "dairy"
+
+
+def test_excludes_other_months():
+    result = get_monthly_intake("R001", "2026-02")
+    # Only SKU004 was delivered in Feb for R001
+    assert result["total_items_received"] == 1
+    assert result["intake"][0]["item_id"] == "SKU004"
+
+
+def test_excludes_other_restaurants():
+    result = get_monthly_intake("R002", "2026-03")
+    item_ids = {i["item_id"] for i in result["intake"]}
+    assert "SKU001" not in item_ids
+    assert "SKU005" in item_ids
+    assert "SKU006" in item_ids
+
+
+def test_empty_result_for_unknown_restaurant():
+    result = get_monthly_intake("R999", "2026-03")
+    assert result["total_items_received"] == 0
+    assert result["total_units"] == 0
+    assert result["intake"] == []
+
+
+def test_invalid_month_raises():
+    with pytest.raises(ValueError, match="Invalid month format"):
+        get_monthly_intake("R001", "March-2026")


### PR DESCRIPTION
## Summary
Implements #2 — monthly inventory intake report per restaurant.

- `GET /inventory/intake?restaurant_id=<id>&month=<YYYY-MM>` endpoint
- Per-item breakdown: name, category, units received, delivery dates
- Aggregated totals: `total_units` and `total_items_received`
- Input validation with 422 on bad month format
- In-memory data store (ready to swap for a real DB)

## Example response
```json
{
  "restaurant_id": "R001",
  "month": "2026-03",
  "total_items_received": 3,
  "total_units": 535,
  "intake": [
    {
      "item_id": "SKU001",
      "name": "Whole Milk",
      "category": "dairy",
      "units_received": 200,
      "delivery_dates": ["2026-03-01", "2026-03-08", "2026-03-15"]
    }
  ]
}
```

## Test plan
- [x] Returns correct items for restaurant + month
- [x] Excludes items from other months
- [x] Excludes items from other restaurants
- [x] Returns empty result for unknown restaurant
- [x] Raises error on invalid month format
- [x] 7 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)