### PR TITLE
feat: login page with role-based authentication

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1947,6 +1948,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3157,6 +3171,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3227,6 +3279,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,68 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { AuthProvider, useAuth } from './context/AuthContext'
+import LoginPage from './components/LoginPage'
 import IntakeForm from './components/IntakeForm'
+import ProtectedRoute from './components/ProtectedRoute'
 
-export default function App() {
+function Header() {
+  const { user, logout } = useAuth()
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
-      <header className="bg-white border-b border-slate-200 shadow-sm">
-        <div className="max-w-5xl mx-auto px-6 py-4 flex items-center gap-3">
+    <header className="bg-white border-b border-slate-200 shadow-sm">
+      <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
           <span className="text-2xl">🏪</span>
           <div>
             <h1 className="text-xl font-bold text-slate-800">Inventory Waste Predictor</h1>
             <p className="text-xs text-slate-500">Powered by AI</p>
           </div>
         </div>
-      </header>
-      <main className="max-w-5xl mx-auto px-6 py-8">
-        <IntakeForm />
-      </main>
+        {user && (
+          <div className="flex items-center gap-4">
+            <div className="text-right">
+              <p className="text-sm font-semibold text-slate-700">👤 {user.username}</p>
+              <p className="text-xs text-blue-600 font-medium">{user.role}</p>
+            </div>
+            <button
+              onClick={logout}
+              className="text-sm px-4 py-2 rounded-lg border border-slate-200 text-slate-600 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
+            >
+              🔓 Logout
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  )
+}
+
+function Layout({ children }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
+      <Header />
+      <main className="max-w-5xl mx-auto px-6 py-8">{children}</main>
     </div>
+  )
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <Layout>
+                  <IntakeForm />
+                </Layout>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }

--- a/frontend/src/components/LoginPage.jsx
+++ b/frontend/src/components/LoginPage.jsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      const res = await fetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        setError(data.detail || 'Invalid username or password.')
+        return
+      }
+
+      login(data)
+      navigate('/')
+    } catch {
+      setError('Unable to connect to server. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+
+        {/* Logo / Brand */}
+        <div className="text-center mb-8">
+          <div className="text-5xl mb-3">🏪</div>
+          <h1 className="text-2xl font-bold text-slate-800">Inventory Waste Predictor</h1>
+          <p className="text-sm text-slate-500 mt-1">Powered by AI</p>
+        </div>
+
+        {/* Card */}
+        <div className="bg-white rounded-2xl shadow-md border border-slate-200 overflow-hidden">
+          <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-8 py-6">
+            <h2 className="text-white text-lg font-semibold">Welcome Back 👋</h2>
+            <p className="text-blue-100 text-sm mt-1">Please sign in to continue</p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="px-8 py-6 space-y-5">
+
+            {/* Username */}
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Username
+              </label>
+              <input
+                type="text"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+                placeholder="Enter your username"
+                required
+                autoFocus
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
+              />
+            </div>
+
+            {/* Password */}
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                  required
+                  className="w-full border border-slate-300 rounded-lg px-4 py-2.5 pr-12 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(v => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 text-sm transition"
+                  tabIndex={-1}
+                >
+                  {showPassword ? '🙈' : '👁️'}
+                </button>
+              </div>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm flex items-center gap-2">
+                <span>⚠️</span>
+                <span>{error}</span>
+              </div>
+            )}
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-2.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed rounded-lg transition-colors flex items-center justify-center gap-2"
+            >
+              {loading ? (
+                <><span className="animate-spin">⏳</span> Signing in…</>
+              ) : (
+                <><span>🔐</span> Sign In</>
+              )}
+            </button>
+
+          </form>
+        </div>
+
+        <p className="text-center text-xs text-slate-400 mt-6">
+          Contact your administrator if you need access.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,7 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+export default function ProtectedRoute({ children }) {
+  const { user } = useAuth()
+  return user ? children : <Navigate to="/login" replace />
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useState } from 'react'
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    try {
+      const stored = localStorage.getItem('auth')
+      return stored ? JSON.parse(stored) : null
+    } catch {
+      return null
+    }
+  })
+
+  const login = (userData) => {
+    localStorage.setItem('auth', JSON.stringify(userData))
+    setUser(userData)
+  }
+
+  const logout = async () => {
+    if (user?.token) {
+      await fetch('/auth/logout', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${user.token}` },
+      }).catch(() => {})
+    }
+    localStorage.removeItem('auth')
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/inventory': 'http://localhost:8000',
+      '/auth': 'http://localhost:8000',
     },
   },
 })

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
-from src.api.routes import predict, items, report, intake
+from fastapi.middleware.cors import CORSMiddleware
+from src.api.routes import predict, items, report, intake, auth
 
 app = FastAPI(
     title="Inventory Waste Predictor API",
@@ -7,6 +8,15 @@ app = FastAPI(
     version="0.1.0",
 )
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://localhost:5174"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 app.include_router(predict.router, prefix="/predict", tags=["Prediction"])
 app.include_router(items.router, prefix="/items", tags=["Items"])
 app.include_router(report.router, prefix="/report", tags=["Report"])

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, HTTPException, Header
+from pydantic import BaseModel
+from src.services.auth_service import login, get_current_user, logout
+
+router = APIRouter()
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class AuthResponse(BaseModel):
+    token: str
+    username: str
+    role: str
+
+
+class UserResponse(BaseModel):
+    username: str
+    role: str
+
+
+@router.post("/login", response_model=AuthResponse)
+def auth_login(body: LoginRequest):
+    try:
+        return login(body.username, body.password)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+
+@router.get("/me", response_model=UserResponse)
+def auth_me(authorization: str = Header(...)):
+    token = authorization.removeprefix("Bearer ").strip()
+    try:
+        return get_current_user(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+
+@router.post("/logout")
+def auth_logout(authorization: str = Header(...)):
+    token = authorization.removeprefix("Bearer ").strip()
+    logout(token)
+    return {"message": "Logged out successfully."}

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -1,0 +1,41 @@
+"""
+Auth service — hardcoded user store, easy to replace with a real DB.
+"""
+import uuid
+
+# User store: extend this dict to add more users/roles
+USERS = {
+    "Admin": {"password": "admin", "role": "Manager"},
+}
+
+# In-memory token store: { token: { username, role } }
+_SESSIONS: dict[str, dict] = {}
+
+
+def login(username: str, password: str) -> dict:
+    """
+    Validate credentials and return a session token.
+    Raises ValueError on invalid credentials.
+    """
+    user = USERS.get(username)
+    if not user or user["password"] != password:
+        raise ValueError("Invalid username or password.")
+
+    token = str(uuid.uuid4())
+    _SESSIONS[token] = {"username": username, "role": user["role"]}
+    return {"token": token, "username": username, "role": user["role"]}
+
+
+def get_current_user(token: str) -> dict:
+    """
+    Look up a session token and return the user info.
+    Raises ValueError if token is invalid or expired.
+    """
+    session = _SESSIONS.get(token)
+    if not session:
+        raise ValueError("Invalid or expired session token.")
+    return session
+
+
+def logout(token: str) -> None:
+    _SESSIONS.pop(token, None)

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,38 @@
+import pytest
+from src.services.auth_service import login, get_current_user, logout
+
+
+def test_valid_login():
+    result = login("Admin", "admin")
+    assert result["username"] == "Admin"
+    assert result["role"] == "Manager"
+    assert "token" in result
+
+
+def test_invalid_password():
+    with pytest.raises(ValueError, match="Invalid username or password"):
+        login("Admin", "wrongpassword")
+
+
+def test_invalid_username():
+    with pytest.raises(ValueError, match="Invalid username or password"):
+        login("unknown", "admin")
+
+
+def test_get_current_user():
+    result = login("Admin", "admin")
+    user = get_current_user(result["token"])
+    assert user["username"] == "Admin"
+    assert user["role"] == "Manager"
+
+
+def test_invalid_token():
+    with pytest.raises(ValueError, match="Invalid or expired session token"):
+        get_current_user("not-a-real-token")
+
+
+def test_logout_invalidates_token():
+    result = login("Admin", "admin")
+    logout(result["token"])
+    with pytest.raises(ValueError, match="Invalid or expired session token"):
+        get_current_user(result["token"])


### PR DESCRIPTION
## Summary
Implements #6 — login page with username/password auth and role-based session.

### Backend
- `POST /auth/login` — validates credentials, returns `{ token, username, role }`
- `GET /auth/me` — verifies bearer token, returns current user
- `POST /auth/logout` — invalidates session token
- In-memory user store (swap for DB when ready):
  ```python
  USERS = { "Admin": { "password": "admin", "role": "Manager" } }
  ```
- CORS middleware added for `localhost:5173` and `localhost:5174`

### Frontend
- **LoginPage** — clean form with show/hide password toggle, loading state, inline errors
- **AuthContext** — `{ user, login, logout }` via React Context + `localStorage` persistence
- **ProtectedRoute** — redirects unauthenticated users to `/login`
- **Header** — shows `👤 Admin` / `Manager` role badge + logout button when signed in
- React Router handles `/login` and `/` routes

### Credentials
| Username | Password | Role |
|----------|----------|------|
| `Admin` | `admin` | `Manager` |

## Test plan
- [x] Unauthenticated → redirected to `/login`
- [x] Wrong credentials → inline error shown
- [x] Correct credentials → redirect to home, header shows `Admin (Manager)`
- [x] Show/hide password toggle works
- [x] Refresh → session restored from localStorage
- [x] Logout → session cleared, redirect to `/login`
- [x] 6 unit tests for auth service passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)