### PR TITLE
feat: inventory list view with date filter and role-based actions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import LoginPage from './components/LoginPage'
 import IntakeForm from './components/IntakeForm'
+import InventoryList from './components/InventoryList'
 import ProtectedRoute from './components/ProtectedRoute'
 
 function Header() {
@@ -44,6 +45,13 @@ function Layout({ children }) {
   )
 }
 
+function ManagerRoute({ children }) {
+  const { user } = useAuth()
+  if (!user) return <Navigate to="/login" replace />
+  if (user.role !== 'Manager') return <Navigate to="/" replace />
+  return children
+}
+
 export default function App() {
   return (
     <AuthProvider>
@@ -54,10 +62,16 @@ export default function App() {
             path="/"
             element={
               <ProtectedRoute>
-                <Layout>
-                  <IntakeForm />
-                </Layout>
+                <Layout><InventoryList /></Layout>
               </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/intake"
+            element={
+              <ManagerRoute>
+                <Layout><IntakeForm /></Layout>
+              </ManagerRoute>
             }
           />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/DateFilter.jsx
+++ b/frontend/src/components/DateFilter.jsx
@@ -1,0 +1,30 @@
+export default function DateFilter({ fromDate, toDate, onFromChange, onToChange, onFilter }) {
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <div>
+        <label className="block text-xs font-medium text-slate-500 mb-1">From</label>
+        <input
+          type="date"
+          value={fromDate}
+          onChange={e => onFromChange(e.target.value)}
+          className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-slate-500 mb-1">To</label>
+        <input
+          type="date"
+          value={toDate}
+          onChange={e => onToChange(e.target.value)}
+          className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <button
+        onClick={onFilter}
+        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+      >
+        🔍 Filter
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/EditItemModal.jsx
+++ b/frontend/src/components/EditItemModal.jsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import { useAuth } from '../context/AuthContext'
+
+const CATEGORIES = ['dairy', 'bakery', 'produce', 'meat', 'dry-goods', 'beverages', 'frozen']
+
+export default function EditItemModal({ item, restaurantId, onClose, onSaved }) {
+  const { user } = useAuth()
+  const [name, setName] = useState(item.name)
+  const [category, setCategory] = useState(item.category)
+  const [units, setUnits] = useState(item.units)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSave = async () => {
+    setError('')
+    setSaving(true)
+    try {
+      const res = await fetch(
+        `/inventory/list/${item.item_id}?restaurant_id=${restaurantId}&delivery_date=${item.delivery_date}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${user.token}`,
+          },
+          body: JSON.stringify({ name, category, units: Number(units) }),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'Failed to update.')
+      onSaved()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden">
+        <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-white font-semibold">Edit Inventory Item</h3>
+            <p className="text-blue-100 text-xs mt-0.5 font-mono">{item.item_id} · {item.delivery_date}</p>
+          </div>
+          <button onClick={onClose} className="text-white/70 hover:text-white text-xl leading-none">×</button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Item Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Category</label>
+            <select
+              value={category}
+              onChange={e => setCategory(e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+            >
+              {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Units</label>
+            <input
+              type="number"
+              min="1"
+              value={units}
+              onChange={e => setUnits(e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm flex items-center gap-2">
+              <span>⚠️</span><span>{error}</span>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3 pt-1">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-5 py-2 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-60 rounded-lg transition-colors"
+            >
+              {saving ? '⏳ Saving…' : '💾 Save Changes'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -1,0 +1,134 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+import DateFilter from './DateFilter'
+import InventoryTable from './InventoryTable'
+import EditItemModal from './EditItemModal'
+
+const RESTAURANT_ID = 'R001'
+
+const today = new Date()
+const defaultFrom = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10)
+const defaultTo = today.toISOString().slice(0, 10)
+
+export default function InventoryList() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const isManager = user?.role === 'Manager'
+
+  const [fromDate, setFromDate] = useState(defaultFrom)
+  const [toDate, setToDate] = useState(defaultTo)
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [editingItem, setEditingItem] = useState(null)
+
+  const fetchInventory = async (from, to) => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(
+        `/inventory/list/?restaurant_id=${RESTAURANT_ID}&from_date=${from}&to_date=${to}`,
+        { headers: { Authorization: `Bearer ${user.token}` } }
+      )
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.detail || 'Failed to load inventory.')
+      setData(json)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchInventory(fromDate, toDate) }, [])
+
+  const handleFilter = () => fetchInventory(fromDate, toDate)
+
+  const handleSaved = () => {
+    setEditingItem(null)
+    fetchInventory(fromDate, toDate)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div>
+          <h2 className="text-xl font-bold text-slate-800">📦 Inventory List</h2>
+          <p className="text-sm text-slate-500 mt-0.5">Restaurant {RESTAURANT_ID}</p>
+        </div>
+        {isManager ? (
+          <button
+            onClick={() => navigate('/intake')}
+            className="px-5 py-2.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+          >
+            + Add Inventory
+          </button>
+        ) : (
+          <div className="flex items-center gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
+            <span>🔒</span>
+            <span>View-only access — contact a Manager to make changes</span>
+          </div>
+        )}
+      </div>
+
+      {/* Filter card */}
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-200 px-6 py-4">
+        <DateFilter
+          fromDate={fromDate}
+          toDate={toDate}
+          onFromChange={setFromDate}
+          onToChange={setToDate}
+          onFilter={handleFilter}
+        />
+      </div>
+
+      {/* Results card */}
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
+        {/* Stats bar */}
+        {data && (
+          <div className="px-6 py-3 border-b border-slate-100 flex items-center justify-between text-sm bg-slate-50">
+            <span className="text-slate-600">
+              <strong className="text-slate-800">{data.total_items}</strong> records found
+            </span>
+            <span className="text-slate-600">
+              Total units: <strong className="text-slate-800">{data.total_units}</strong>
+            </span>
+          </div>
+        )}
+
+        <div className="p-4">
+          {loading && (
+            <div className="text-center py-16 text-slate-400">
+              <div className="text-3xl mb-2 animate-spin">⏳</div>
+              <p>Loading inventory…</p>
+            </div>
+          )}
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm flex items-center gap-2">
+              <span>⚠️</span><span>{error}</span>
+            </div>
+          )}
+          {!loading && !error && data && (
+            <InventoryTable
+              items={data.items}
+              isManager={isManager}
+              onEdit={setEditingItem}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Edit modal */}
+      {editingItem && (
+        <EditItemModal
+          item={editingItem}
+          restaurantId={RESTAURANT_ID}
+          onClose={() => setEditingItem(null)}
+          onSaved={handleSaved}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/InventoryTable.jsx
+++ b/frontend/src/components/InventoryTable.jsx
@@ -1,0 +1,65 @@
+const CATEGORY_COLORS = {
+  dairy:      'bg-blue-100 text-blue-700',
+  bakery:     'bg-yellow-100 text-yellow-700',
+  produce:    'bg-green-100 text-green-700',
+  meat:       'bg-red-100 text-red-700',
+  'dry-goods':'bg-slate-100 text-slate-700',
+  beverages:  'bg-purple-100 text-purple-700',
+  frozen:     'bg-cyan-100 text-cyan-700',
+}
+
+export default function InventoryTable({ items, isManager, onEdit }) {
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-16 text-slate-400">
+        <div className="text-4xl mb-3">📭</div>
+        <p className="font-medium">No inventory records found</p>
+        <p className="text-sm mt-1">Try adjusting the date filter</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-slate-200 rounded-xl overflow-hidden">
+      {/* Header */}
+      <div className={`grid ${isManager ? 'grid-cols-12' : 'grid-cols-11'} bg-slate-50 border-b border-slate-200 px-4 py-2.5 text-xs font-semibold text-slate-500 uppercase tracking-wide`}>
+        <div className="col-span-2">Item ID</div>
+        <div className="col-span-3">Name</div>
+        <div className="col-span-2">Category</div>
+        <div className="col-span-2 text-right">Units</div>
+        <div className="col-span-2 text-right">Delivery Date</div>
+        {isManager && <div className="col-span-1"></div>}
+      </div>
+
+      {/* Rows */}
+      <div className="divide-y divide-slate-100">
+        {items.map((item, i) => (
+          <div
+            key={i}
+            className={`grid ${isManager ? 'grid-cols-12' : 'grid-cols-11'} px-4 py-3 items-center hover:bg-slate-50 transition-colors text-sm text-slate-700`}
+          >
+            <div className="col-span-2 font-mono text-xs text-slate-500">{item.item_id}</div>
+            <div className="col-span-3 font-medium">{item.name}</div>
+            <div className="col-span-2">
+              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${CATEGORY_COLORS[item.category] || 'bg-slate-100 text-slate-600'}`}>
+                {item.category}
+              </span>
+            </div>
+            <div className="col-span-2 text-right font-semibold">{item.units}</div>
+            <div className="col-span-2 text-right text-slate-500">{item.delivery_date}</div>
+            {isManager && (
+              <div className="col-span-1 flex justify-end">
+                <button
+                  onClick={() => onEdit(item)}
+                  className="text-xs px-2.5 py-1 rounded-lg border border-slate-200 text-slate-600 hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200 transition-colors"
+                >
+                  ✏️ Edit
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,0 +1,31 @@
+"""
+FastAPI dependencies for authentication and role-based access control.
+"""
+from fastapi import Header, HTTPException
+from src.services.auth_service import get_current_user
+
+
+def require_auth(authorization: str = Header(...)):
+    """Require any authenticated user. Returns current user dict."""
+    token = authorization.removeprefix("Bearer ").strip()
+    try:
+        return get_current_user(token)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid or missing auth token.")
+
+
+def require_role(*roles: str):
+    """Return a dependency that requires the user to have one of the given roles."""
+    def dependency(authorization: str = Header(...)):
+        token = authorization.removeprefix("Bearer ").strip()
+        try:
+            user = get_current_user(token)
+        except ValueError:
+            raise HTTPException(status_code=401, detail="Invalid or missing auth token.")
+        if user["role"] not in roles:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied. Required role: {' or '.join(roles)}.",
+            )
+        return user
+    return dependency

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from src.api.routes import predict, items, report, intake, auth
+from src.api.routes import predict, items, report, intake, auth, inventory
 
 app = FastAPI(
     title="Inventory Waste Predictor API",
@@ -21,6 +21,7 @@ app.include_router(predict.router, prefix="/predict", tags=["Prediction"])
 app.include_router(items.router, prefix="/items", tags=["Items"])
 app.include_router(report.router, prefix="/report", tags=["Report"])
 app.include_router(intake.router, prefix="/inventory/intake", tags=["Intake"])
+app.include_router(inventory.router, prefix="/inventory/list", tags=["Inventory"])
 
 
 @app.get("/health")

--- a/src/api/routes/intake.py
+++ b/src/api/routes/intake.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from src.api.dependencies import require_auth, require_role
 from src.services.intake_service import get_monthly_intake, add_intake_records
 
 router = APIRouter()
@@ -44,7 +45,7 @@ class SubmitIntakeResponse(BaseModel):
     total_units: int
 
 
-@router.get("/", response_model=IntakeResponse)
+@router.get("/", response_model=IntakeResponse, dependencies=[Depends(require_auth)])
 def monthly_intake(
     restaurant_id: str = Query(..., description="Restaurant identifier"),
     month: str = Query(..., description="Month in YYYY-MM format", pattern=r"^\d{4}-\d{2}$"),
@@ -55,7 +56,7 @@ def monthly_intake(
         raise HTTPException(status_code=422, detail=str(e))
 
 
-@router.post("/", response_model=SubmitIntakeResponse)
+@router.post("/", response_model=SubmitIntakeResponse, dependencies=[Depends(require_role("Manager"))])
 def submit_intake(body: SubmitIntakeRequest):
     if not body.delivery_date.startswith(body.month):
         raise HTTPException(

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from src.api.dependencies import require_auth, require_role
+from src.services.intake_service import get_inventory_by_date, update_intake_record
+
+router = APIRouter()
+
+
+class InventoryItem(BaseModel):
+    item_id: str
+    name: str
+    category: str
+    units: int
+    delivery_date: str
+
+
+class InventoryListResponse(BaseModel):
+    restaurant_id: str
+    from_date: str
+    to_date: str
+    total_items: int
+    total_units: int
+    items: list[InventoryItem]
+
+
+class EditItemRequest(BaseModel):
+    name: str
+    category: str
+    units: int
+
+
+@router.get("/", response_model=InventoryListResponse)
+def list_inventory(
+    restaurant_id: str = Query(...),
+    from_date: str = Query(..., pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    to_date: str = Query(..., pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    user=Depends(require_auth),
+):
+    data = get_inventory_by_date(restaurant_id, from_date, to_date)
+    return InventoryListResponse(
+        restaurant_id=data["restaurant_id"],
+        from_date=data["from"],
+        to_date=data["to"],
+        total_items=data["total_items"],
+        total_units=data["total_units"],
+        items=data["items"],
+    )
+
+
+@router.patch("/{item_id}", dependencies=[Depends(require_role("Manager"))])
+def edit_inventory_item(
+    item_id: str,
+    body: EditItemRequest,
+    restaurant_id: str = Query(...),
+    delivery_date: str = Query(..., pattern=r"^\d{4}-\d{2}-\d{2}$"),
+):
+    updated = update_intake_record(
+        restaurant_id, item_id, delivery_date,
+        {"name": body.name, "category": body.category, "units": body.units},
+    )
+    if not updated:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Record not found.")
+    return {"message": "Record updated successfully."}

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -5,7 +5,8 @@ import uuid
 
 # User store: extend this dict to add more users/roles
 USERS = {
-    "Admin": {"password": "admin", "role": "Manager"},
+    "Admin":  {"password": "admin",  "role": "Manager"},
+    "Viewer": {"password": "viewer", "role": "Viewer"},
 }
 
 # In-memory token store: { token: { username, role } }

--- a/src/services/intake_service.py
+++ b/src/services/intake_service.py
@@ -72,6 +72,40 @@ def get_monthly_intake(restaurant_id: str, month: str) -> dict:
     }
 
 
+def get_inventory_by_date(restaurant_id: str, from_date: str, to_date: str) -> dict:
+    """
+    Return all inventory records for a restaurant between from_date and to_date (inclusive).
+    """
+    records = [
+        r for r in _INTAKE_RECORDS
+        if r["restaurant_id"] == restaurant_id
+        and from_date <= r["delivery_date"] <= to_date
+    ]
+    items = sorted(records, key=lambda x: x["delivery_date"])
+    return {
+        "restaurant_id": restaurant_id,
+        "from": from_date,
+        "to": to_date,
+        "total_items": len(items),
+        "total_units": sum(r["units"] for r in items),
+        "items": items,
+    }
+
+
+def update_intake_record(restaurant_id: str, item_id: str, delivery_date: str, updates: dict) -> bool:
+    """
+    Update an existing record matching restaurant_id + item_id + delivery_date.
+    Returns True if found and updated, False otherwise.
+    """
+    for record in _INTAKE_RECORDS:
+        if (record["restaurant_id"] == restaurant_id
+                and record["item_id"] == item_id
+                and record["delivery_date"] == delivery_date):
+            record.update(updates)
+            return True
+    return False
+
+
 def add_intake_records(body) -> None:
     """
     Append submitted intake items to the in-memory store.


### PR DESCRIPTION
## Summary
Implements #9 and closes #8 — inventory list page with date filter, role-based actions, and API-level RBAC.

### Backend
- `GET /inventory/list` — returns inventory filtered by `from_date`, `to_date`, `restaurant_id`. Requires auth.
- `PATCH /inventory/list/{item_id}` — edit item name/category/units. Requires `Manager` role.
- `require_auth` / `require_role()` dependency factory for clean RBAC on any route
- `GET` and `POST /inventory/intake` now enforce `401`/`403`
- Added `Viewer` user: username `Viewer`, password `viewer`, role `Viewer`

### Frontend
- **InventoryList** — main landing page, loads current month by default
- **DateFilter** — from/to date pickers + Filter button
- **InventoryTable** — shows `✏️ Edit` column only for Managers; colour-coded category badges
- **EditItemModal** — pre-filled modal, PATCHes record, refreshes list on save
- **ManagerRoute** — non-Managers redirected away from `/intake`
- Viewer sees read-only banner: `🔒 View-only access — contact a Manager to make changes`

### Role Matrix
| Action | Manager | Viewer |
|--------|---------|--------|
| View inventory list | ✅ | ✅ |
| Filter by date | ✅ | ✅ |
| Edit item | ✅ | ❌ |
| Add inventory | ✅ | ❌ |

### Test credentials
| Username | Password | Role |
|----------|----------|------|
| `Admin` | `admin` | Manager |
| `Viewer` | `viewer` | Viewer |

🤖 Generated with [Claude Code](https://claude.com/claude-code)