### PR TITLE
feat: monthly consumption summary with waste calculation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AuthProvider, useAuth } from './context/AuthContext'
 import LoginPage from './components/LoginPage'
 import IntakeForm from './components/IntakeForm'
 import InventoryList from './components/InventoryList'
+import MonthlySummary from './components/MonthlySummary'
 import ProtectedRoute from './components/ProtectedRoute'
 
 function Header() {
@@ -72,6 +73,14 @@ export default function App() {
               <ManagerRoute>
                 <Layout><IntakeForm /></Layout>
               </ManagerRoute>
+            }
+          />
+          <Route
+            path="/summary"
+            element={
+              <ProtectedRoute>
+                <Layout><MonthlySummary /></Layout>
+              </ProtectedRoute>
             }
           />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -59,16 +59,32 @@ export default function InventoryList() {
           <p className="text-sm text-slate-500 mt-0.5">Restaurant {RESTAURANT_ID}</p>
         </div>
         {isManager ? (
-          <button
-            onClick={() => navigate('/intake')}
-            className="px-5 py-2.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
-          >
-            + Add Inventory
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => navigate('/summary')}
+              className="px-4 py-2.5 text-sm font-semibold text-blue-600 bg-white border border-blue-300 hover:bg-blue-50 rounded-lg transition-colors flex items-center gap-2"
+            >
+              📊 Monthly Summary
+            </button>
+            <button
+              onClick={() => navigate('/intake')}
+              className="px-5 py-2.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+            >
+              + Add Inventory
+            </button>
+          </div>
         ) : (
-          <div className="flex items-center gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
-            <span>🔒</span>
-            <span>View-only access — contact a Manager to make changes</span>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate('/summary')}
+              className="px-4 py-2.5 text-sm font-semibold text-blue-600 bg-white border border-blue-300 hover:bg-blue-50 rounded-lg transition-colors flex items-center gap-2"
+            >
+              📊 Monthly Summary
+            </button>
+            <div className="flex items-center gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
+              <span>🔒</span>
+              <span>View-only access</span>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/MonthlySummary.jsx
+++ b/frontend/src/components/MonthlySummary.jsx
@@ -1,0 +1,287 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+const RESTAURANT_ID = 'R001'
+
+const today = new Date()
+const defaultMonth = today.toISOString().slice(0, 7)
+
+const WASTE_STYLES = {
+  green: { bar: 'bg-green-500', badge: 'bg-green-100 text-green-700', icon: '🟢' },
+  amber: { bar: 'bg-amber-400', badge: 'bg-amber-100 text-amber-700', icon: '🟡' },
+  red:   { bar: 'bg-red-500',   badge: 'bg-red-100 text-red-700',     icon: '🔴' },
+}
+
+function WasteBadge({ level, pct }) {
+  const s = WASTE_STYLES[level] || WASTE_STYLES.green
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full ${s.badge}`}>
+      {s.icon} {pct}%
+    </span>
+  )
+}
+
+function WasteBar({ pct }) {
+  const level = pct <= 15 ? 'green' : pct <= 30 ? 'amber' : 'red'
+  return (
+    <div className="w-full bg-slate-100 rounded-full h-1.5 mt-1">
+      <div
+        className={`h-1.5 rounded-full transition-all ${WASTE_STYLES[level].bar}`}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  )
+}
+
+export default function MonthlySummary() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const isManager = user?.role === 'Manager'
+
+  const [month, setMonth] = useState(defaultMonth)
+  const [data, setData] = useState(null)
+  const [consumed, setConsumed] = useState({})   // { item_id: value }
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  const fetchSummary = async (m) => {
+    setLoading(true)
+    setError('')
+    setSaved(false)
+    try {
+      const res = await fetch(
+        `/inventory/summary/?restaurant_id=${RESTAURANT_ID}&month=${m}`,
+        { headers: { Authorization: `Bearer ${user.token}` } }
+      )
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.detail || 'Failed to load summary.')
+      setData(json)
+      // Seed editable consumed values from fetched data
+      const init = {}
+      json.items.forEach(i => { init[i.item_id] = i.units_consumed })
+      setConsumed(init)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchSummary(month) }, [])
+
+  const handleMonthChange = (m) => { setMonth(m); fetchSummary(m) }
+
+  // Live-calculate waste for a row using current consumed input
+  const liveRow = (item) => {
+    const c = Number(consumed[item.item_id] ?? item.units_consumed)
+    const waste = Math.max(item.units_purchased - c, 0)
+    const pct = item.units_purchased ? Math.round((waste / item.units_purchased) * 100 * 10) / 10 : 0
+    const level = pct <= 15 ? 'green' : pct <= 30 ? 'amber' : 'red'
+    return { consumed: c, waste, pct, level }
+  }
+
+  const liveTotals = () => {
+    if (!data) return { purchased: 0, consumed: 0, waste: 0, pct: 0, level: 'green' }
+    const purchased = data.items.reduce((s, i) => s + i.units_purchased, 0)
+    const cons = data.items.reduce((s, i) => s + Number(consumed[i.item_id] ?? i.units_consumed), 0)
+    const waste = Math.max(purchased - cons, 0)
+    const pct = purchased ? Math.round((waste / purchased) * 100 * 10) / 10 : 0
+    const level = pct <= 15 ? 'green' : pct <= 30 ? 'amber' : 'red'
+    return { purchased, consumed: cons, waste, pct, level }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError('')
+    try {
+      const entries = Object.entries(consumed).map(([item_id, units_consumed]) => ({
+        item_id,
+        units_consumed: Number(units_consumed),
+      }))
+      const res = await fetch('/inventory/summary/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ restaurant_id: RESTAURANT_ID, month, entries }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.detail || 'Failed to save.')
+      setSaved(true)
+      fetchSummary(month)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const totals = liveTotals()
+
+  return (
+    <div className="space-y-6">
+
+      {/* Page header */}
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div>
+          <h2 className="text-xl font-bold text-slate-800">📊 Monthly Consumption Summary</h2>
+          <p className="text-sm text-slate-500 mt-0.5">Restaurant {RESTAURANT_ID} — track purchased vs consumed</p>
+        </div>
+        <button
+          onClick={() => navigate('/')}
+          className="text-sm px-4 py-2 rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50 transition-colors"
+        >
+          ← Back to Inventory
+        </button>
+      </div>
+
+      {/* Month picker */}
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-200 px-6 py-4 flex items-end gap-4">
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">Month</label>
+          <input
+            type="month"
+            value={month}
+            onChange={e => handleMonthChange(e.target.value)}
+            className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        {!isManager && (
+          <div className="flex items-center gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2">
+            <span>🔒</span><span>View-only — only Managers can enter consumed quantities</span>
+          </div>
+        )}
+      </div>
+
+      {/* Summary card */}
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
+
+        {/* Totals bar */}
+        {data && (
+          <div className="grid grid-cols-4 divide-x divide-slate-100 border-b border-slate-200">
+            {[
+              { label: 'Total Purchased', value: totals.purchased, color: 'text-blue-600' },
+              { label: 'Total Consumed',  value: totals.consumed,  color: 'text-green-600' },
+              { label: 'Total Waste',     value: totals.waste,     color: 'text-red-600' },
+              { label: 'Overall Waste %', value: null,             color: '' },
+            ].map(({ label, value, color }, i) => (
+              <div key={i} className="px-6 py-4 text-center">
+                <p className="text-xs text-slate-500 uppercase tracking-wide mb-1">{label}</p>
+                {value !== null
+                  ? <p className={`text-2xl font-bold ${color}`}>{value}</p>
+                  : <div className="flex flex-col items-center gap-1">
+                      <WasteBadge level={totals.level} pct={totals.pct} />
+                      <WasteBar pct={totals.pct} />
+                    </div>
+                }
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Table */}
+        {loading && (
+          <div className="text-center py-16 text-slate-400">
+            <div className="text-3xl mb-2 animate-spin">⏳</div>
+            <p>Loading summary…</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="m-4 bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm flex items-center gap-2">
+            <span>⚠️</span><span>{error}</span>
+          </div>
+        )}
+
+        {!loading && !error && data && data.items.length === 0 && (
+          <div className="text-center py-16 text-slate-400">
+            <div className="text-4xl mb-3">📭</div>
+            <p className="font-medium">No intake records for {month}</p>
+            <p className="text-sm mt-1">Add inventory first via the intake form</p>
+          </div>
+        )}
+
+        {!loading && !error && data && data.items.length > 0 && (
+          <div className="overflow-x-auto">
+            {/* Table header */}
+            <div className="grid grid-cols-12 bg-slate-50 border-b border-slate-200 px-4 py-2.5 text-xs font-semibold text-slate-500 uppercase tracking-wide min-w-[700px]">
+              <div className="col-span-2">Item ID</div>
+              <div className="col-span-2">Name</div>
+              <div className="col-span-1">Category</div>
+              <div className="col-span-2 text-right">Purchased</div>
+              <div className="col-span-2 text-right">Consumed</div>
+              <div className="col-span-1 text-right">Waste</div>
+              <div className="col-span-2 text-right">Waste %</div>
+            </div>
+
+            {/* Rows */}
+            <div className="divide-y divide-slate-100 min-w-[700px]">
+              {data.items.map(item => {
+                const live = liveRow(item)
+                return (
+                  <div key={item.item_id} className="grid grid-cols-12 px-4 py-3 items-center hover:bg-slate-50 transition-colors text-sm text-slate-700">
+                    <div className="col-span-2 font-mono text-xs text-slate-500">{item.item_id}</div>
+                    <div className="col-span-2 font-medium">{item.name}</div>
+                    <div className="col-span-1">
+                      <span className="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">{item.category}</span>
+                    </div>
+                    <div className="col-span-2 text-right font-semibold text-blue-700">{item.units_purchased}</div>
+                    <div className="col-span-2 text-right">
+                      {isManager ? (
+                        <input
+                          type="number"
+                          min="0"
+                          max={item.units_purchased}
+                          value={consumed[item.item_id] ?? item.units_consumed}
+                          onChange={e => setConsumed(prev => ({ ...prev, [item.item_id]: e.target.value }))}
+                          className="w-24 border border-slate-300 rounded-lg px-2 py-1 text-sm text-right focus:outline-none focus:ring-2 focus:ring-blue-500 ml-auto"
+                        />
+                      ) : (
+                        <span className="font-semibold text-green-700">{live.consumed}</span>
+                      )}
+                    </div>
+                    <div className="col-span-1 text-right font-semibold text-red-600">{live.waste}</div>
+                    <div className="col-span-2 text-right">
+                      <div className="flex flex-col items-end gap-1">
+                        <WasteBadge level={live.level} pct={live.pct} />
+                        <WasteBar pct={live.pct} />
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Save footer — Manager only */}
+        {isManager && data && data.items.length > 0 && (
+          <div className="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between">
+            <div className="text-sm text-slate-500">
+              {saved && <span className="text-green-600 font-medium">✅ Saved successfully</span>}
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-6 py-2.5 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-60 rounded-lg transition-colors flex items-center gap-2"
+            >
+              {saving ? <><span className="animate-spin">⏳</span> Saving…</> : <>💾 Save Summary</>}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-6 text-xs text-slate-500">
+        <span className="font-medium">Waste thresholds:</span>
+        <span className="flex items-center gap-1">🟢 &lt;15% acceptable</span>
+        <span className="flex items-center gap-1">🟡 15–30% monitor</span>
+        <span className="flex items-center gap-1">🔴 &gt;30% action required</span>
+      </div>
+    </div>
+  )
+}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from src.api.routes import predict, items, report, intake, auth, inventory
+from src.api.routes import predict, items, report, intake, auth, inventory, summary
 
 app = FastAPI(
     title="Inventory Waste Predictor API",
@@ -22,6 +22,7 @@ app.include_router(items.router, prefix="/items", tags=["Items"])
 app.include_router(report.router, prefix="/report", tags=["Report"])
 app.include_router(intake.router, prefix="/inventory/intake", tags=["Intake"])
 app.include_router(inventory.router, prefix="/inventory/list", tags=["Inventory"])
+app.include_router(summary.router, prefix="/inventory/summary", tags=["Summary"])
 
 
 @app.get("/health")

--- a/src/api/routes/summary.py
+++ b/src/api/routes/summary.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from src.api.dependencies import require_auth, require_role
+from src.services.summary_service import get_monthly_summary, save_consumption
+
+router = APIRouter()
+
+
+class SummaryItem(BaseModel):
+    item_id: str
+    name: str
+    category: str
+    units_purchased: int
+    units_consumed: int
+    waste: int
+    waste_pct: float
+    waste_level: str   # green | amber | red
+
+
+class SummaryResponse(BaseModel):
+    restaurant_id: str
+    month: str
+    items: list[SummaryItem]
+    total_purchased: int
+    total_consumed: int
+    total_waste: int
+    overall_waste_pct: float
+    overall_waste_level: str
+
+
+class ConsumptionEntry(BaseModel):
+    item_id: str
+    units_consumed: int = Field(ge=0)
+
+
+class SaveConsumptionRequest(BaseModel):
+    restaurant_id: str
+    month: str = Field(pattern=r"^\d{4}-\d{2}$")
+    entries: list[ConsumptionEntry] = Field(min_length=1)
+
+
+@router.get("/", response_model=SummaryResponse)
+def monthly_summary(
+    restaurant_id: str = Query(...),
+    month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    user=Depends(require_auth),
+):
+    return get_monthly_summary(restaurant_id, month)
+
+
+@router.post("/", dependencies=[Depends(require_role("Manager"))])
+def save_monthly_consumption(body: SaveConsumptionRequest):
+    save_consumption(
+        body.restaurant_id,
+        body.month,
+        [e.model_dump() for e in body.entries],
+    )
+    return {"message": "Consumption data saved successfully."}

--- a/src/services/summary_service.py
+++ b/src/services/summary_service.py
@@ -1,0 +1,86 @@
+"""
+Monthly consumption summary service.
+Aggregates purchased quantities from intake records and merges with
+consumed quantities entered by managers to calculate waste.
+"""
+from src.services.intake_service import _INTAKE_RECORDS
+
+# In-memory consumption store: { (restaurant_id, item_id, month): units_consumed }
+_CONSUMPTION: dict[tuple, int] = {
+    ("R001", "SKU001", "2026-03"): 160,
+    ("R001", "SKU002", "2026-03"): 190,
+    ("R001", "SKU003", "2026-03"): 60,
+    ("R001", "SKU004", "2026-02"): 35,
+}
+
+WASTE_THRESHOLDS = {"green": 15, "amber": 30}  # % boundaries
+
+
+def _waste_level(waste_pct: float) -> str:
+    if waste_pct <= WASTE_THRESHOLDS["green"]:
+        return "green"
+    if waste_pct <= WASTE_THRESHOLDS["amber"]:
+        return "amber"
+    return "red"
+
+
+def get_monthly_summary(restaurant_id: str, month: str) -> dict:
+    """
+    Aggregate all purchased units for the month, merge with consumed
+    quantities, and compute waste per item.
+    """
+    # Aggregate purchased per item_id for the month
+    purchased: dict[str, dict] = {}
+    for r in _INTAKE_RECORDS:
+        if r["restaurant_id"] == restaurant_id and r["delivery_date"].startswith(month):
+            key = r["item_id"]
+            if key not in purchased:
+                purchased[key] = {
+                    "item_id": key,
+                    "name": r["name"],
+                    "category": r["category"],
+                    "units_purchased": 0,
+                }
+            purchased[key]["units_purchased"] += r["units"]
+
+    # Build summary rows
+    items = []
+    for item_id, p in sorted(purchased.items()):
+        consumed = _CONSUMPTION.get((restaurant_id, item_id, month), 0)
+        waste = max(p["units_purchased"] - consumed, 0)
+        waste_pct = round((waste / p["units_purchased"]) * 100, 1) if p["units_purchased"] else 0.0
+        items.append({
+            "item_id": item_id,
+            "name": p["name"],
+            "category": p["category"],
+            "units_purchased": p["units_purchased"],
+            "units_consumed": consumed,
+            "waste": waste,
+            "waste_pct": waste_pct,
+            "waste_level": _waste_level(waste_pct),
+        })
+
+    total_purchased = sum(i["units_purchased"] for i in items)
+    total_consumed = sum(i["units_consumed"] for i in items)
+    total_waste = max(total_purchased - total_consumed, 0)
+    overall_waste_pct = round((total_waste / total_purchased) * 100, 1) if total_purchased else 0.0
+
+    return {
+        "restaurant_id": restaurant_id,
+        "month": month,
+        "items": items,
+        "total_purchased": total_purchased,
+        "total_consumed": total_consumed,
+        "total_waste": total_waste,
+        "overall_waste_pct": overall_waste_pct,
+        "overall_waste_level": _waste_level(overall_waste_pct),
+    }
+
+
+def save_consumption(restaurant_id: str, month: str, entries: list[dict]) -> None:
+    """
+    Save or update consumed quantities for a month.
+    Each entry: { item_id, units_consumed }
+    """
+    for entry in entries:
+        _CONSUMPTION[(restaurant_id, entry["item_id"], month)] = entry["units_consumed"]

--- a/tests/test_summary_service.py
+++ b/tests/test_summary_service.py
@@ -1,0 +1,54 @@
+import pytest
+from src.services.summary_service import get_monthly_summary, save_consumption
+
+
+def test_summary_returns_correct_month():
+    result = get_monthly_summary("R001", "2026-03")
+    assert result["restaurant_id"] == "R001"
+    assert result["month"] == "2026-03"
+    assert len(result["items"]) == 3  # SKU001, SKU002, SKU003
+
+
+def test_waste_calculated_correctly():
+    result = get_monthly_summary("R001", "2026-03")
+    milk = next(i for i in result["items"] if i["item_id"] == "SKU001")
+    assert milk["units_purchased"] == 200
+    assert milk["units_consumed"] == 160
+    assert milk["waste"] == 40
+    assert milk["waste_pct"] == 20.0
+    assert milk["waste_level"] == "amber"
+
+
+def test_totals_are_correct():
+    result = get_monthly_summary("R001", "2026-03")
+    assert result["total_purchased"] == 535
+    assert result["total_consumed"] == 410
+    assert result["total_waste"] == 125
+
+
+def test_waste_level_green():
+    result = get_monthly_summary("R001", "2026-03")
+    bread = next(i for i in result["items"] if i["item_id"] == "SKU002")
+    assert bread["waste_level"] == "green"
+
+
+def test_waste_level_red():
+    result = get_monthly_summary("R001", "2026-03")
+    tomatoes = next(i for i in result["items"] if i["item_id"] == "SKU003")
+    assert tomatoes["waste_level"] == "red"
+
+
+def test_save_consumption_updates_waste():
+    save_consumption("R001", "2026-03", [{"item_id": "SKU001", "units_consumed": 195}])
+    result = get_monthly_summary("R001", "2026-03")
+    milk = next(i for i in result["items"] if i["item_id"] == "SKU001")
+    assert milk["units_consumed"] == 195
+    assert milk["waste"] == 5
+    assert milk["waste_level"] == "green"
+
+
+def test_empty_month_returns_no_items():
+    result = get_monthly_summary("R001", "2020-01")
+    assert result["items"] == []
+    assert result["total_purchased"] == 0
+    assert result["total_waste"] == 0


### PR DESCRIPTION
## Summary
Implements #11 (Option B) — dedicated monthly summary page to track purchased vs consumed inventory and auto-calculate waste.

### Backend
- `GET /inventory/summary?restaurant_id=R001&month=2026-03` — aggregates purchased units from intake records, merges with consumed quantities, returns waste per item
- `POST /inventory/summary` — saves consumed quantities (Manager only)
- Waste formula: `waste = purchased − consumed`
- Waste % colour levels: 🟢 <15% / 🟡 15–30% / 🔴 >30%
- Pre-seeded consumption data for R001 March 2026

### Frontend
- **MonthlySummary page** (`/summary`) — accessible to all authenticated users
- Month picker — change month and reload instantly
- **Totals bar** — Total Purchased / Consumed / Waste / Overall Waste %
- **Item table** — per-row waste badge + mini progress bar
- Managers get editable Consumed inputs — waste recalculates live as they type
- **Save Summary** button (Manager only) with success confirmation
- User role sees read-only view with view-only banner
- 📊 Monthly Summary button added to Inventory List header for both roles

### Waste Thresholds
| Level | Range | Badge |
|-------|-------|-------|
| Green | < 15% | 🟢 |
| Amber | 15–30% | 🟡 |
| Red | > 30% | 🔴 |

### Test plan
- [x] Summary loads with correct purchased totals from intake records
- [x] Waste calculates correctly per item and overall
- [x] Waste levels assigned correctly (green/amber/red)
- [x] Manager edits consumed → waste updates live
- [x] Save stores values, refresh shows updated data
- [x] User role sees read-only view
- [x] Empty month shows friendly empty state
- [x] 7 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)