### PR TITLE
chore: add security scan workflow for feature branches

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,92 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - 'refactor/**'
+  pull_request:
+    branches: [main]
+
+jobs:
+  python-dependency-scan:
+    name: Python Dependency Audit (pip-audit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit Python dependencies
+        run: pip-audit -r requirements.txt --format markdown >> $GITHUB_STEP_SUMMARY
+
+  python-static-analysis:
+    name: Python Static Security Analysis (bandit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install bandit
+        run: pip install bandit
+
+      - name: Run bandit
+        run: |
+          bandit -r src/ \
+            --severity-level medium \
+            --confidence-level medium \
+            --format txt \
+            --exit-zero \
+            | tee bandit-report.txt
+          echo "### Bandit Security Report" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat bandit-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload bandit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report
+          path: bandit-report.txt
+
+  frontend-dependency-scan:
+    name: Frontend Dependency Audit (npm audit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Audit frontend dependencies
+        working-directory: frontend
+        run: |
+          npm audit --audit-level=moderate --json > npm-audit.json || true
+          echo "### npm Audit Report" >> $GITHUB_STEP_SUMMARY
+          npm audit --audit-level=moderate 2>&1 | tee npm-audit.txt >> $GITHUB_STEP_SUMMARY || true
+
+      - name: Upload npm audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: frontend/npm-audit.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/security.yml` triggered on push to `feature/**`, `fix/**`, `refactor/**` and on PRs to `main`
- **pip-audit** — scans Python dependencies in `requirements.txt` for known CVEs, publishes results to step summary
- **bandit** — static security analysis of `src/` at medium severity/confidence, uploads report as artifact
- **npm audit** — scans frontend `node_modules` for vulnerabilities at moderate level, uploads JSON report as artifact

## Test plan
- [x] All 3 security scan jobs passed on `feature/security-scan-ci` push (run #22623080699)
- [x] Bandit report and npm audit report uploaded as downloadable artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)